### PR TITLE
Tidy 5e Sheets compatibility update

### DIFF
--- a/src/scripts/raritycolors.js
+++ b/src/scripts/raritycolors.js
@@ -33,25 +33,20 @@ Hooks.on("tidy5e-sheet.renderActorSheet", (app, element) => {
     if (!rarityFlag) {
         return;
     }
+
     const options = {
-        itemSelector: "[data-tidy-item-table-row]",
-        itemNameSelector: "[data-tidy-item-name]",
-    };
+        itemSelector: `[data-tidy-sheet-part='item-table-row'] .item-table-row`,
+        itemNameSelector: `[data-tidy-sheet-part='item-name']`,
+    }
     // Undo any existing color overrides
     const html = $(element);
     if (options.itemSelector) {
         html.find(options.itemSelector).css("background-color", "");
+        html.find(options.itemSelector).css("background", "");
         html.find(options.itemSelector).css("color", "");
-    }
-    if (options.itemSelector2) {
-        html.find(options.itemSelector2).css("background-color", "");
-        html.find(options.itemSelector2).css("color", "");
     }
     if (html.find(options.itemNameSelector)?.length > 0) {
         html.find(options.itemNameSelector).css("color", "");
-    }
-    if (html.find(options.itemNameSelector2)?.length > 0) {
-        html.find(options.itemNameSelector2).css("color", "");
     }
     renderActorRarityColors(app, $(element), options);
 });
@@ -145,7 +140,8 @@ export function renderActorRarityColors(actorSheet, html, options) {
     // let items = html.find($(options.itemSelector));
     for (let itemElement of items) {
         // let id = itemElement.outerHTML.match(/data-item-id="(.*?)"/);
-        let id = itemElement.dataset.itemId;
+        // Get closest available Item dataset.
+        let id = itemElement.closest('[data-item-id]')?.dataset.itemId;
         if (!id) {
             continue;
         }
@@ -175,7 +171,9 @@ export function renderActorRarityColors(actorSheet, html, options) {
             if (color && !colorIsDefault(color)) {
                 if (game.settings.get(CONSTANTS.MODULE_ID, "enableBackgroundColorInsteadText")) {
                     const backgroundColor = API.getRarityTextBackgroundColor(color);
+                    // Target background-color and background to ensure there are no overlapping backgrounds.
                     itemNameElement.css("background-color", backgroundColor);
+                    itemNameElement.css("background", backgroundColor);
                     if (game.modules.get("colorsettings")?.api) {
                         const textColor = API.getRarityTextColor(color);
                         itemNameElement.css("color", textColor);


### PR DESCRIPTION
This is a PR to restore compatibility with Tidy 5e Sheets. When Tidy introduced an animation container for pure CSS toggles on its item rows, as well as limiting row color just to the row and not the item summary, the change in HTML broke compatibility with rarity colors.

Things I did to restore compat:

Updated Tidy's selectors to work with the latest version of the module.

Updated item dataset retrieval to perform a `closest` check, to handle cases like Tidy's, where the row to colorize is not also the dataset node. It still works the same for other sheets.

Updated the background setting code to also set the `background` in addition to `background-color`, to prevent cases like backgrounds with gradients overlapping with the rarity color unintentionally.

I tested functionality with the new default sheets, and they seem to still be in working order.