### PR TITLE
quick fix: adding Tidy v7.5.0 compatibility

### DIFF
--- a/src/scripts/raritycolors.js
+++ b/src/scripts/raritycolors.js
@@ -37,7 +37,7 @@ Hooks.on("tidy5e-sheet.renderActorSheet", (app, element) => {
     }
 
     const options = {
-        itemSelector: `[data-tidy-sheet-part='item-table-row'] .item-table-row`,
+        itemSelector: `[data-tidy-sheet-part='item-table-row'] .item-table-row, [data-tidy-sheet-part='item-table-row'].item-table-row`,
         itemNameSelector: `[data-tidy-sheet-part='item-name']`,
         itemImageNameSelector: `.item-image`,
     };


### PR DESCRIPTION
Adds support for Tidy v7.5.0 item tables while remaining compatible with pre-7.5.0.